### PR TITLE
Remove usage of deprecated Initialization to support latest ModLoadSeparator

### DIFF
--- a/Loader/CVRModUpdaterPlugin.cs
+++ b/Loader/CVRModUpdaterPlugin.cs
@@ -19,7 +19,7 @@ namespace CVRModUpdater.Loader
         string targetDirectoryPath  = Path.Combine(MelonHandler.ModsDirectory, "..", "UserData");
         string targetFilePath       = Path.Combine(MelonHandler.ModsDirectory, "..", "UserData", "CVRModUpdater.Core.dll");
 
-        public override void OnApplicationStart()
+        public override void OnApplicationEarlyStart()
         {
 
             if (Environment.GetCommandLineArgs().Contains("--updater-dev"))


### PR DESCRIPTION
This makes it work with the latest [ModLoadSeparator](https://github.com/RinLovesYou/CVRMods/tree/master/ModLoadSeparator), since it also updated to removed the deprecated Initialization: https://github.com/RinLovesYou/CVRMods/commit/f34521b014fe0e2221e6611369280c5c50057bfd

Without this the updater fails to update Mods inside of `/Desktop` or `/VR` folders.